### PR TITLE
Update Postgresql to 13.6

### DIFF
--- a/modules/postgresql.json
+++ b/modules/postgresql.json
@@ -13,8 +13,8 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://ftp.postgresql.org/pub/source/v13.3/postgresql-13.3.tar.bz2",
-            "sha256": "3cd9454fa8c7a6255b6743b767700925ead1b9ab0d7a0f9dcb1151010f8eb4a1"
+            "url": "https://ftp.postgresql.org/pub/source/v13.6/postgresql-13.6.tar.bz2",
+            "sha256": "bafc7fa3d9d4da8fe71b84c63ba8bdfe8092935c30c0aa85c24b2c08508f67fc"
         }
     ]
 }


### PR DESCRIPTION
Just a maintenance update. A test build is at https://github.com/flathub/org.gnucash.GnuCash/pull/52. Works as expected for me.